### PR TITLE
Bump clap version to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,26 +94,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.21"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -124,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -465,12 +463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,16 +485,6 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -787,12 +769,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["/.vscode"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.2.20", features = ["derive"] }
-gtk = { version = "0.4.8" , package = "gtk4"}
+clap = { version = "4.0", features = ["derive"] }
+gtk = { version = "0.4.8", package = "gtk4" }
 infer = "0.9"
 opener = "0.5"
 url = "2.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 use std::thread;
 use std::io::{self, BufRead};
 use std::path::PathBuf;
+
 use clap::Parser;
 use url::Url;
 
@@ -10,69 +11,68 @@ use gtk::glib::{self,clone, Continue, MainContext, PRIORITY_DEFAULT, Bytes, Type
 use gtk::gdk::{ContentProvider, DragAction};
 use gtk::gio::ApplicationFlags;
 
-/// Drag and Drop files to and from the terminal
 #[derive(Parser)]
-#[clap(about)]
+#[command(about, version)]
 struct Cli {
     /// Be verbose
-    #[clap(short, long, value_parser, default_value_t = false)]
+    #[arg(short, long)]
     verbose: bool,
 
     /// Act as a target instead of source
-    #[clap(short, long, value_parser, default_value_t = false)]
+    #[arg(short, long)]
     target: bool,
 
     /// With --target, keep files to drag out
-    #[clap(short, long, value_parser, default_value_t = false, requires = "target")]
+    #[arg(short, long, requires = "target")]
     keep: bool,
 
     /// With --target, keep files to drag out
-    #[clap(short, long, value_parser, default_value_t = false, requires = "target")]
+    #[arg(short, long, requires = "target")]
     print_path: bool,
 
     /// Make the window resizable
-    #[clap(short, long, value_parser, default_value_t = false)]
+    #[arg(short, long)]
     resizable: bool,
     
     /// Exit after first successful drag or drop 
-    #[clap(short = 'x', long, value_parser, default_value_t = false)]
+    #[arg(short = 'x', long)]
     and_exit: bool,
 
     /// Only display icons, no labels
-    #[clap(short, long, value_parser, default_value_t = false)]
+    #[arg(short, long)]
     icons_only: bool,
 
     /// Don't load thumbnails from images
-    #[clap(short, long, value_parser, default_value_t = false)]
+    #[arg(short, long)]
     disable_thumbnails: bool,
 
     /// Size of icons and thumbnails
-    #[clap(short = 's', long, value_parser, default_value_t = 32)]
+    #[arg(short = 's', long, value_name = "SIZE", default_value_t = 32)]
     icon_size: i32,
 
     /// Min width of the main window
-    #[clap(short = 'w', long, value_parser, default_value_t = 360)]
+    #[arg(short = 'W', long, value_name = "WIDTH", default_value_t = 360)]
     content_width: i32,
 
     /// Default height of the main window
-    #[clap(short = 'h', long, value_parser, default_value_t = 360)]
+    #[arg(short = 'H', long, value_name = "HEIGHT", default_value_t = 360)]
     content_height: i32,
 
     /// Accept paths from stdin
-    #[clap(short = 'I', long, value_parser, default_value_t = false)]
+    #[arg(short = 'I', long)]
     from_stdin: bool,
 
     /// Drag all the items together
-    #[clap(short = 'a', long, value_parser, default_value_t = false)]
+    #[arg(short = 'a', long)]
     all: bool,
 
     /// Show only the number of items and drag them together
-    #[clap(short = 'A', long, value_parser, default_value_t = false)]
+    #[arg(short = 'A', long)]
     all_compact: bool,
 
     /// Paths to the files you want to drag
-    #[clap(parse(from_os_str))]
-    paths: Vec<std::path::PathBuf>,
+    #[arg(value_name = "PATH")]
+    paths: Vec<PathBuf>,
 }
 
 fn main() {


### PR DESCRIPTION
This should make the code a bit more readable.

Important notes:

- switched the short width and height flags to `-W` and `-H` to make them consistent and avoid conflict with `-h` for help
- made the file paths conflict with the `--from-stdin` flag via an `ArgGroup`
- clap 4 no longer colors the help prompt in any way, just simple line underlines, bold font etc.
- added autogenerated `--version` flag