### PR TITLE
Many changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,59 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "autocfg"
@@ -21,13 +70,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bstr"
-version = "1.3.0"
+name = "bitflags"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "once_cell",
  "regex-automata",
  "serde",
 ]
@@ -40,11 +94,11 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cairo-rs"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8af54f5d48af1226928adc1f57edd22f5df1349e7da1fc96ae15cf43db0e871"
+checksum = "ab3603c4028a5e368d09b51c8b624b9a46edcd7c3778284077a6125af73c9f0a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -54,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55382a01d30e5e53f185eee269124f5e21ab526595b872751278dfbb463594e"
+checksum = "691d0c66b1fb4881be80a760cb8fe76ea97218312f9dfe2c9cc0f496ca279cb1"
 dependencies = [
  "glib-sys",
  "libc",
@@ -82,59 +136,76 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.11.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0357a6402b295ca3a86bc148e84df46c02e41f41fef186bda662557ef6328aa"
+checksum = "b40ccee03b5175c18cde8f37e7d2a33bcef6f8ec8f7cc0d81090d1bb380949c9"
 dependencies = [
  "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
- "bitflags",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "is-terminal",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.8"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -149,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "field-offset"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf3a800ff6e860c863ca6d4b16fd999db8b752819c1606884047b73e468535"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
@@ -165,33 +236,33 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -200,32 +271,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -237,11 +308,11 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b023fbe0c6b407bd3d9805d107d9800da3829dc5a676653210f1d5f16d7f59bf"
+checksum = "695d6bc846438c5708b07007537b9274d883373dd30858ca881d7d71b5540717"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gdk-pixbuf-sys",
  "gio",
  "glib",
@@ -251,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b41bd2b44ed49d99277d3925652a163038bd5ed943ec9809338ffb2f4391e3b"
+checksum = "9285ec3c113c66d7d0ab5676599176f1f42f4944ca1b581852215bf5694870cb"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -264,11 +335,11 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5042053ee765aeef08d9d7e3f0f1e36a4d37f1659b3f93ad3d6997515dbb64a"
+checksum = "c3abf96408a26e3eddf881a7f893a1e111767137136e347745e8ea6ed12731ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "gdk-pixbuf",
  "gdk4-sys",
@@ -280,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f0fb00507af1e9299681dd09965f720e2b5ea95536d49a5681e8994ef10c7a"
+checksum = "1bc92aa1608c089c49393d014c38ac0390d01e4841e1fedaa75dbcef77aaed64"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -297,11 +368,11 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.17.3"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b46cd098567b42c8f1b55c23ecb80ff3b3e07aa298d03aacc46c8f1b4cf1186"
+checksum = "a6973e92937cf98689b6a054a9e56c657ed4ff76de925e36fc331a15f0c5d30a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -317,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d3076ecb86c8c3a672c9843d6232b3a344fb81d304d0ba1ac64b23343efa46"
+checksum = "0ccf87c30a12c469b6d958950f6a9c09f2be20b7773f7e70d20b867fdf2628c3"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -330,11 +401,11 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.17.3"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ce6595f2fb74b90d15680d5c2d84cf89ca03c8ff96dcd8f4a8a6c214e629b3"
+checksum = "d3fad45ba8d4d2cea612b432717e834f48031cd8853c8aaf43b2c79fec8d144b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -353,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.17.3"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5281157383168967254909b5f9973bc6bbfcc958760719a79a6b334689d6de3"
+checksum = "eca5c79337338391f1ab8058d6698125034ce8ef31b72a442437fa6c8580de26"
 dependencies = [
  "anyhow",
  "heck",
@@ -363,14 +434,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.17.2"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a0985cf568e18cf63b443c9a14f4bdaa947fed7437476000dba84926a20b25"
+checksum = "d80aa6ea7bba0baac79222204aa786a6293078c210abe69ef1336911d4bdc4f0"
 dependencies = [
  "libc",
  "system-deps",
@@ -378,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0155d388840c77d61b033b66ef4f9bc7f4133d83df83572d6b4fb234a3be7d"
+checksum = "cd34c3317740a6358ec04572c1bcfd3ac0b5b6529275fae255b237b314bb8062"
 dependencies = [
  "glib-sys",
  "libc",
@@ -389,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.17.1"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cf11565bb0e4dfc2f99d4775b6c329f0d40a2cff9c0066214d31a0e1b46256"
+checksum = "def4bb01265b59ed548b05455040d272d989b3012c42d4c1bbd39083cb9b40d9"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -400,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-sys"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80a4849a8d9565410a8fec6fc3678e9c617f4ac7be182ca55ab75016e07af9"
+checksum = "1856fc817e6a6675e36cea0bd9a3afe296f5d9709d1e2d3182803ac77f0ab21d"
 dependencies = [
  "glib-sys",
  "libc",
@@ -412,11 +483,11 @@ dependencies = [
 
 [[package]]
 name = "gsk4"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa9cd285a72a95124b65c069a9cb1b8fb8e310be71783404c39fccf3bf7774c"
+checksum = "6f01ef44fa7cac15e2da9978529383e6bee03e570ba5bf7036b4c10a15cc3a3c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "gdk4",
  "glib",
@@ -428,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a445ae1e50cbf181a1d5c61b920a7e7e8657b96e0ecdbbf8911a86fad462a32"
+checksum = "c07a84fb4dcf1323d29435aa85e2f5f58bef564342bef06775ec7bd0da1f01b0"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -444,11 +515,11 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.6.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47dca53cb1a8ae3006e869b5711ae7370180db537f6d98e3bcaf23fabfd911f"
+checksum = "b28a32a04cd75cef14a0983f8b0c669e0fe152a0a7725accdeb594e2c764c88b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "field-offset",
  "futures-channel",
@@ -467,23 +538,23 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.6.0"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4676c4f90d8b010e88cb4558f61f47d76d6f6b8e6f6b89e62640f443907f61"
+checksum = "6a4d6b61570f76d3ee542d984da443b1cd69b6105264c61afec3abed08c2500f"
 dependencies = [
  "anyhow",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "gtk4-sys"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65463dc801460e498d5e7ffa6e9ae2cfbed7d05fabd1ca5a8d024adbc89eeda6"
+checksum = "5f8283f707b07e019e76c7f2934bdd4180c277e08aa93f4c0d8dd07b7a34e22f"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -500,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -512,15 +583,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -528,11 +599,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
@@ -546,38 +617,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "io-lifetimes",
  "rustix",
  "windows-sys",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "memchr"
@@ -587,18 +647,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opener"
@@ -611,18 +671,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
 name = "pango"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243c048be90312220fb3bd578176eed8290568274a93c95040289d39349384bc"
+checksum = "35be456fc620e61f62dff7ff70fbd54dcbaf0a4b920c0f16de1107c47d921d48"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gio",
  "glib",
  "libc",
@@ -632,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.17.0"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4293d0f0b5525eb5c24734d30b0ed02cd02aa734f216883f376b54de49625de8"
+checksum = "3da69f9f3850b0d8990d462f8c709561975e95f689c1cdf0fecdebde78b35195"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -644,15 +698,15 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -662,9 +716,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "proc-macro-crate"
@@ -685,7 +739,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -702,27 +756,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 
 [[package]]
 name = "ripdrag"
@@ -746,13 +800,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys",
@@ -760,15 +813,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "60363bdd39a7be0266a520dab25fdc9241d2f987b08a01e01f0ec6d06a981348"
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "slab"
@@ -781,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "strsim"
@@ -803,10 +865,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-deps"
-version = "6.0.3"
+name = "syn"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2955b1fe31e1fa2fbd1976b71cc69a606d7d4da16f6de3333d0c92d51419aeff"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "system-deps"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c2de8a4d8f4b823d634affc9cd2a74ec98c53a756f317e529a48046cbf71f3"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -816,32 +889,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
+name = "target-lexicon"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
+checksum = "1d2faeef5759ab89935255b1a4cd98e0baf99d1085e37d36599c625dac49ae8e"
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -861,41 +931,49 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
-
-[[package]]
 name = "toml_edit"
-version = "0.19.5"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7082a95d48029677a28f181e5f6422d0c8339ad8396a39d3f33d62a90c1f6c30"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -908,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -918,10 +996,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.3.0"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "version-compare"
@@ -952,15 +1036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,18 +1043,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -992,51 +1067,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
  "futures-task",
  "futures-util",
  "gio-sys",
- "glib-macros",
+ "glib-macros 0.17.10",
  "glib-sys",
  "gobject-sys",
  "libc",
@@ -435,6 +435,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179643c50bf28d20d2f6eacd2531a88f2f5d9747dd0b86b8af1e8bb5dd0de3c0"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -783,6 +797,7 @@ name = "ripdrag"
 version = "0.3.2"
 dependencies = [
  "clap",
+ "glib-macros 0.18.0",
  "gtk4",
  "infer",
  "opener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["/.vscode"]
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
 gtk = { version = "0.6.6", package = "gtk4", features = ["v4_10"] }
+glib-macros = "0.18.0"
 infer = "0.13.0"
 opener = "0.5.2"
 url = "2.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/.vscode"]
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
-gtk = { version = "0.6.6", package = "gtk4", features = ["v4_10"] }
+gtk = { version = "0.6.6", package = "gtk4", features = ["v4_6"] }
 glib-macros = "0.18.0"
 infer = "0.13.0"
 opener = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/.vscode"]
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
-gtk = { version = "0.6.2", package = "gtk4", features = ["v4_6"] }
+gtk = { version = "0.6.6", package = "gtk4", features = ["v4_10"] }
 infer = "0.13.0"
 opener = "0.5.2"
 url = "2.3.1"

--- a/src/compact_view.rs
+++ b/src/compact_view.rs
@@ -12,19 +12,20 @@ pub fn generate_compact_view() -> ListWidget {
     let drag_source = DragSource::new();
     setup_drag_source_all(&drag_source, &file_model);
 
+    let obj = CompactLabel::new(file_model);
+    let model = obj.model();
+    let obj = obj.upcast::<Widget>();
+
+    // styling
     let provider = CssProvider::new();
     provider.load_from_data(include_str!("style.css"));
-
     gtk::style_context_add_provider_for_display(
         &gtk::gdk::Display::default().expect("Could not connect to a display."),
         &provider,
         gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
     );
-
-    let obj = CompactLabel::new(file_model);
-    let model = obj.model();
-    let obj = obj.upcast::<Widget>();
     obj.add_css_class("drag");
+    obj.set_cursor_from_name(Some("grab"));
 
     obj.add_controller(drag_source);
     setup_drop_target(&model, &obj);

--- a/src/compact_view.rs
+++ b/src/compact_view.rs
@@ -41,6 +41,7 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Orientable, gtk::Buildable, gtk::ConstraintTarget;
 }
 
+// This is necessary to keep the model alive, otherwise it will be dropped.
 impl CompactLabel {
     pub fn new(model: ListStore) -> Self {
         let create_string = |arg| format!("{} elements", arg);

--- a/src/compact_view.rs
+++ b/src/compact_view.rs
@@ -1,20 +1,16 @@
 use glib::Object;
 use gtk::gio::ListStore;
-use gtk::glib;
+use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use gtk::CssProvider;
-use gtk::DragSource;
-use gtk::Widget;
-use gtk::{prelude::*, Label};
+use gtk::{glib, CssProvider, DragSource, Label, Widget};
 
-use crate::util::setup_drop_target;
-use crate::util::{drag_source_all, setup_file_model, ListWidget};
+use crate::util::{generate_file_model, setup_drag_source_all, setup_drop_target, ListWidget};
 
 pub fn generate_compact_view() -> ListWidget {
-    let file_model = setup_file_model();
+    let file_model = generate_file_model();
 
     let drag_source = DragSource::new();
-    drag_source_all(&drag_source, &file_model);
+    setup_drag_source_all(&drag_source, &file_model);
 
     let provider = CssProvider::new();
     provider.load_from_data(include_str!("style.css"));
@@ -68,9 +64,12 @@ impl CompactLabel {
 }
 
 mod imp {
-    use super::*;
-    use gtk::{glib::Properties, Align, Orientation};
     use std::cell::RefCell;
+
+    use gtk::glib::Properties;
+    use gtk::{Align, Orientation};
+
+    use super::*;
 
     #[derive(Default, Properties)]
     #[properties(wrapper_type = super::CompactLabel)]

--- a/src/compact_view.rs
+++ b/src/compact_view.rs
@@ -1,0 +1,31 @@
+use gtk::DragSource;
+use gtk::Widget;
+use gtk::{prelude::*, Label};
+
+use crate::util::{drag_source_all, setup_file_model, ListWidget};
+
+pub fn generate_compact_view() -> ListWidget {
+    let file_model = setup_file_model();
+    let create_string = |arg| format!("{} elements", arg);
+
+    let obj = Label::builder()
+        .label(create_string(file_model.n_items()))
+        .ellipsize(gtk::pango::EllipsizeMode::End)
+        .halign(gtk::Align::Center)
+        .tooltip_text(format!("Drag {}", create_string(file_model.n_items())))
+        .build();
+    file_model
+        .bind_property("n-items", &obj, "label")
+        .transform_to(|_, item_count: u32| Some(format!("{} elements", item_count)))
+        .build();
+
+    let drag_source = DragSource::new();
+    drag_source_all(&drag_source, &file_model);
+
+    obj.add_controller(drag_source);
+
+    ListWidget {
+        list_model: file_model,
+        widget: obj.upcast::<Widget>(),
+    }
+}

--- a/src/compact_view.rs
+++ b/src/compact_view.rs
@@ -2,6 +2,7 @@ use glib::Object;
 use gtk::gio::ListStore;
 use gtk::glib;
 use gtk::subclass::prelude::*;
+use gtk::CssProvider;
 use gtk::DragSource;
 use gtk::Widget;
 use gtk::{prelude::*, Label};
@@ -14,7 +15,18 @@ pub fn generate_compact_view() -> ListWidget {
     let drag_source = DragSource::new();
     drag_source_all(&drag_source, &file_model);
 
+    let provider = CssProvider::new();
+    provider.load_from_data(include_str!("style.css"));
+
+    // Add the provider to the default screen
+    gtk::style_context_add_provider_for_display(
+        &gtk::gdk::Display::default().expect("Could not connect to a display."),
+        &provider,
+        gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+
     let obj = CompactLabel::new(file_model);
+    obj.add_css_class("drag");
 
     obj.add_controller(drag_source);
 
@@ -32,28 +44,29 @@ glib::wrapper! {
 
 impl CompactLabel {
     pub fn new(model: ListStore) -> Self {
-                    let create_string = |arg| format!("{} elements", arg);
+        let create_string = |arg| format!("{} elements", arg);
         let obj: Self = Object::builder().property("model", model).build();
         let label = Label::builder()
-                .label(create_string(obj.model().n_items()))
-                .ellipsize(gtk::pango::EllipsizeMode::End)
-                .halign(gtk::Align::Center)
-                .tooltip_text(format!("Drag {}", create_string(obj.model().n_items())))
-                .build();
-            obj.set_label(label);
+            .label(create_string(obj.model().n_items()))
+            .ellipsize(gtk::pango::EllipsizeMode::End)
+            .tooltip_text(format!("Drag {}", create_string(obj.model().n_items())))
+            .vexpand(true)
+            .hexpand(true)
+            .build();
+        obj.set_label(label);
 
-            obj.append(&obj.label());
-            obj.model()
-                .bind_property("n-items", &obj.label(), "label")
-                .transform_to(|_, item_count: u32| Some(format!("{} elements", item_count)))
-                .build();
+        obj.append(&obj.label());
+        obj.model()
+            .bind_property("n-items", &obj.label(), "label")
+            .transform_to(|_, item_count: u32| Some(format!("{} elements", item_count)))
+            .build();
         obj
     }
 }
 
 mod imp {
     use super::*;
-    use gtk::{glib::Properties, Align};
+    use gtk::{glib::Properties, Align, Orientation};
     use std::cell::RefCell;
 
     #[derive(Default, Properties)]
@@ -71,17 +84,20 @@ mod imp {
         type Type = super::CompactLabel;
         type ParentType = gtk::Box;
     }
-    
+
     #[glib_macros::derived_properties]
     impl ObjectImpl for CompactLabel {
         fn constructed(&self) {
             self.parent_constructed();
             let obj = self.obj();
-            obj.set_halign(Align::Center);
-            obj.set_valign(Align::Center);
+            obj.set_halign(Align::Fill);
+            obj.set_valign(Align::Fill);
+            obj.set_hexpand(true);
+            obj.set_vexpand(true);
+            obj.set_orientation(Orientation::Vertical);
         }
     }
- 
+
     impl WidgetImpl for CompactLabel {}
 
     impl BoxImpl for CompactLabel {}

--- a/src/compact_view.rs
+++ b/src/compact_view.rs
@@ -1,3 +1,7 @@
+use glib::Object;
+use gtk::gio::ListStore;
+use gtk::glib;
+use gtk::subclass::prelude::*;
 use gtk::DragSource;
 use gtk::Widget;
 use gtk::{prelude::*, Label};
@@ -6,26 +10,79 @@ use crate::util::{drag_source_all, setup_file_model, ListWidget};
 
 pub fn generate_compact_view() -> ListWidget {
     let file_model = setup_file_model();
-    let create_string = |arg| format!("{} elements", arg);
-
-    let obj = Label::builder()
-        .label(create_string(file_model.n_items()))
-        .ellipsize(gtk::pango::EllipsizeMode::End)
-        .halign(gtk::Align::Center)
-        .tooltip_text(format!("Drag {}", create_string(file_model.n_items())))
-        .build();
-    file_model
-        .bind_property("n-items", &obj, "label")
-        .transform_to(|_, item_count: u32| Some(format!("{} elements", item_count)))
-        .build();
 
     let drag_source = DragSource::new();
     drag_source_all(&drag_source, &file_model);
 
+    let obj = CompactLabel::new(file_model);
+
     obj.add_controller(drag_source);
 
     ListWidget {
-        list_model: file_model,
+        list_model: obj.model(),
         widget: obj.upcast::<Widget>(),
     }
+}
+
+glib::wrapper! {
+    pub struct CompactLabel(ObjectSubclass<imp::CompactLabel>)
+        @extends gtk::Box, gtk::Widget,
+        @implements gtk::Accessible, gtk::Orientable, gtk::Buildable, gtk::ConstraintTarget;
+}
+
+impl CompactLabel {
+    pub fn new(model: ListStore) -> Self {
+                    let create_string = |arg| format!("{} elements", arg);
+        let obj: Self = Object::builder().property("model", model).build();
+        let label = Label::builder()
+                .label(create_string(obj.model().n_items()))
+                .ellipsize(gtk::pango::EllipsizeMode::End)
+                .halign(gtk::Align::Center)
+                .tooltip_text(format!("Drag {}", create_string(obj.model().n_items())))
+                .build();
+            obj.set_label(label);
+
+            obj.append(&obj.label());
+            obj.model()
+                .bind_property("n-items", &obj.label(), "label")
+                .transform_to(|_, item_count: u32| Some(format!("{} elements", item_count)))
+                .build();
+        obj
+    }
+}
+
+mod imp {
+    use super::*;
+    use gtk::{glib::Properties, Align};
+    use std::cell::RefCell;
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::CompactLabel)]
+    pub struct CompactLabel {
+        #[property(get, construct_only)]
+        pub model: RefCell<ListStore>,
+        #[property(get, set)]
+        pub label: RefCell<Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for CompactLabel {
+        const NAME: &'static str = "RipDragCompactLabel";
+        type Type = super::CompactLabel;
+        type ParentType = gtk::Box;
+    }
+    
+    #[glib_macros::derived_properties]
+    impl ObjectImpl for CompactLabel {
+        fn constructed(&self) {
+            self.parent_constructed();
+            let obj = self.obj();
+            obj.set_halign(Align::Center);
+            obj.set_valign(Align::Center);
+        }
+    }
+ 
+    impl WidgetImpl for CompactLabel {}
+
+    impl BoxImpl for CompactLabel {}
 }

--- a/src/compact_view.rs
+++ b/src/compact_view.rs
@@ -7,6 +7,7 @@ use gtk::DragSource;
 use gtk::Widget;
 use gtk::{prelude::*, Label};
 
+use crate::util::setup_drop_target;
 use crate::util::{drag_source_all, setup_file_model, ListWidget};
 
 pub fn generate_compact_view() -> ListWidget {
@@ -18,7 +19,6 @@ pub fn generate_compact_view() -> ListWidget {
     let provider = CssProvider::new();
     provider.load_from_data(include_str!("style.css"));
 
-    // Add the provider to the default screen
     gtk::style_context_add_provider_for_display(
         &gtk::gdk::Display::default().expect("Could not connect to a display."),
         &provider,
@@ -26,13 +26,16 @@ pub fn generate_compact_view() -> ListWidget {
     );
 
     let obj = CompactLabel::new(file_model);
+    let model = obj.model();
+    let obj = obj.upcast::<Widget>();
     obj.add_css_class("drag");
 
     obj.add_controller(drag_source);
+    setup_drop_target(&model, &obj);
 
     ListWidget {
-        list_model: obj.model(),
-        widget: obj.upcast::<Widget>(),
+        list_model: model,
+        widget: obj,
     }
 }
 

--- a/src/file_object.rs
+++ b/src/file_object.rs
@@ -1,0 +1,50 @@
+use glib::Object;
+use glib::Properties;
+use gtk::gio;
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+glib::wrapper! {
+    pub struct FileObject(ObjectSubclass<imp::FileObject>);
+}
+
+impl FileObject {
+    pub fn new(file: gio::File) -> Self {
+        Object::builder().property("file", file).build()
+    }
+}
+
+mod imp {
+    use super::*;
+    use std::cell::RefCell;
+
+    #[derive(Properties)]
+    #[properties(wrapper_type = super::FileObject)]
+    pub struct FileObject {
+        #[property(get, construct_only)]
+        file: RefCell<gio::File>,
+        #[property(get, set)]
+        thumbnail: RefCell<Option<gtk::Image>>,
+    }
+
+    impl Default for FileObject {
+        fn default() -> Self {
+            Self {
+                file: RefCell::new(gio::File::for_path("/does-not-exist")),
+                thumbnail: RefCell::new(None),
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for FileObject {
+        const NAME: &'static str = "RipDragFileObject";
+        type Type = super::FileObject;
+        type ParentType = glib::Object;
+    }
+
+    // Trait shared by all GObjects
+    #[glib_macros::derived_properties]
+    impl ObjectImpl for FileObject {}
+}

--- a/src/file_object.rs
+++ b/src/file_object.rs
@@ -15,6 +15,12 @@ impl FileObject {
     }
 }
 
+impl Default for FileObject {
+    fn default() -> Self {
+        Self::default()
+    }
+}
+
 mod imp {
     use super::*;
     use std::cell::RefCell;
@@ -25,14 +31,14 @@ mod imp {
         #[property(get, construct_only)]
         file: RefCell<gio::File>,
         #[property(get, set)]
-        thumbnail: RefCell<Option<gtk::Image>>,
+        thumbnail: RefCell<gtk::Image>,
     }
 
     impl Default for FileObject {
         fn default() -> Self {
             Self {
                 file: RefCell::new(gio::File::for_path("/does-not-exist")),
-                thumbnail: RefCell::new(None),
+                thumbnail: RefCell::new(gtk::Image::default()),
             }
         }
     }

--- a/src/file_object.rs
+++ b/src/file_object.rs
@@ -114,23 +114,6 @@ mod imp {
         thumbnail: RefCell<gtk::Image>,
     }
 
-    impl FileObject {
-        fn get_thumbnail(&self) -> gtk::Image {
-            let mime_type = self.file.borrow().mime_type();
-
-            if !ARGS.get().unwrap().disable_thumbnails
-                && gio::content_type_is_mime_type(&mime_type, "image/*")
-            {
-                gtk::Image::builder()
-                    .file(self.file.borrow().parse_name())
-                    .pixel_size(ARGS.get().unwrap().icon_size)
-                    .build()
-            } else {
-                self.thumbnail.borrow().clone()
-            }
-        }
-    }
-
     impl Default for FileObject {
         fn default() -> Self {
             Self {

--- a/src/file_object.rs
+++ b/src/file_object.rs
@@ -1,18 +1,10 @@
-use glib::Object;
-use glib::Properties;
+use gio::{FileInfo, FileQueryInfoFlags};
+use glib::{GString, MainContext, Object, Priority, Properties};
 use glib_macros::clone;
-use gtk::gdk;
-use gtk::gdk_pixbuf;
 use gtk::gdk_pixbuf::Pixbuf;
-use gtk::gio;
-use gtk::gio::FileInfo;
-use gtk::gio::FileQueryInfoFlags;
-use gtk::glib;
-use gtk::glib::GString;
-use gtk::glib::MainContext;
-use gtk::glib::Priority;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
+use gtk::{gdk, gdk_pixbuf, gio, glib};
 
 use crate::ARGS;
 
@@ -103,8 +95,9 @@ impl FileObject {
 }
 
 mod imp {
-    use super::*;
     use std::cell::RefCell;
+
+    use super::*;
 
     #[derive(Properties)]
     #[properties(wrapper_type = super::FileObject)]

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -75,6 +75,7 @@ fn create_drag_source(row: &CenterBox, selection: &MultiSelection) -> DragSource
             }
         }));
     }
+
     drag_source
 }
 
@@ -107,9 +108,11 @@ fn get_file(row: &CenterBox) -> gio::File {
     gio::File::for_path(file_widget.downcast::<Label>().unwrap().text())
 }
 
+// Setup the widgets in the ListView
 fn setup_factory(factory: &SignalListItemFactory, list: &MultiSelection) {
     factory.connect_setup(clone!(@weak list => move |_, list_item| {
         let row = CenterBox::default();
+
         let drag_source = create_drag_source(&row, &list);
         let gesture_click = create_gesture_click(&row);
         row.add_controller(gesture_click);

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -34,7 +34,9 @@ pub fn generate_list_view() -> ListWidget {
         .unwrap();
     let widget = list_view.upcast::<Widget>();
 
-    setup_drop_target(&model, &widget);
+    if ARGS.get().unwrap().keep {
+        setup_drop_target(&model, &widget);
+    }
 
     ListWidget {
         list_model: model,

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -18,8 +18,8 @@ use crate::util::{
 use crate::{ARGS, CURRENT_DIRECTORY};
 
 pub fn generate_list_view() -> ListWidget {
-    let mut list_data = build_list_data();
-    setup_factory(&mut list_data.1, &list_data.0);
+    let list_data = build_list_data();
+    setup_factory(&list_data.1, &list_data.0);
     let list_view = ListView::new(Some(list_data.0), Some(list_data.1));
 
     // lol
@@ -102,7 +102,7 @@ fn get_file(row: &CenterBox) -> gio::File {
     gio::File::for_path(file_widget.downcast::<Label>().unwrap().text())
 }
 
-fn setup_factory(factory: &mut SignalListItemFactory, list: &MultiSelection) {
+fn setup_factory(factory: &SignalListItemFactory, list: &MultiSelection) {
     factory.connect_setup(clone!(@weak list => move |_, list_item| {
         let row = CenterBox::default();
         let drag_source = create_drag_source(&row, &list);

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -1,0 +1,171 @@
+use std::{collections::HashSet, path::PathBuf};
+
+
+use glib::*;
+use glib_macros::clone;
+use gtk::{
+    gdk,
+    gio::{self, ListStore},
+    prelude::*,
+    CenterBox, DragSource, Label, ListItem, ListView, MultiSelection, SignalListItemFactory,
+};
+use url::Url;
+use crate::{file_object::FileObject, ARGS, CURRENT_DIRECTORY};
+use gtk::gdk::*;
+
+pub fn get_list_view() -> ListView {
+    let mut list_data = build_list_data();
+    setup_factory(&mut list_data.1, &list_data.0);
+    ListView::new(Some(list_data.0), Some(list_data.1))
+}
+
+
+fn build_list_data() -> (MultiSelection, SignalListItemFactory) {
+    let file_model = ListStore::new(FileObject::static_type());
+    // setup the file_model
+    if !ARGS.get().unwrap().paths.is_empty() && !ARGS.get().unwrap().all_compact {
+        let files: Vec<FileObject> = ARGS.get().unwrap()
+            .paths
+            .iter()
+            .map(|path| FileObject::new(&gtk::gio::File::for_path(path)))
+            .collect();
+        file_model.extend_from_slice(&files);
+    }
+
+    // setup factory
+    let factory = SignalListItemFactory::new();
+    (MultiSelection::new(Some(file_model)), factory)
+}
+
+fn create_drag_source(row: &CenterBox, selection: &MultiSelection) -> DragSource {
+    let drag_source = DragSource::new();
+    if ARGS.get().unwrap().all {
+        drag_source.connect_prepare(clone!(@weak selection => @default-return None, move |me, _, _| {
+            me.set_state(gtk::EventSequenceState::Claimed);
+            let model = selection.model().unwrap().downcast::<ListStore>().unwrap();
+            let files: Vec<PathBuf> = model.into_iter().flatten().map(|file_object| {file_object.downcast::<FileObject>().unwrap().file().path().unwrap()}).collect();
+            Some(generate_content_provider(&files))
+        }));
+    } else {
+        drag_source.connect_prepare(clone!(@weak row, @weak selection, => @default-return None, move |me, _, _| {
+            me.set_state(gtk::EventSequenceState::Claimed);
+            let selected = selection.selection();
+            let mut set : HashSet<PathBuf> = HashSet::with_capacity(selected.size() as usize);
+            for index in 0..selected.size() {
+                set.insert(selection.item(selected.nth(index as u32)).unwrap().downcast::<FileObject>().unwrap().file().path().unwrap());
+            }
+        
+            let row_file = get_file(&row).path().unwrap();
+            if !set.contains(&row_file)
+            {
+                selection.unselect_all();
+                Some(generate_content_provider(&[row_file]))
+            } else {
+                Some(
+                    generate_content_provider(&set))
+            }
+        }));
+    }
+    drag_source
+}
+
+fn generate_content_provider<'a>(paths: impl IntoIterator<Item = &'a PathBuf>) -> ContentProvider {
+ContentProvider::for_bytes("text/uri-list",     &gtk::glib::Bytes::from_owned(
+        paths
+            .into_iter()
+            .map(|path| -> String {
+                Url::from_file_path(path.canonicalize().unwrap())
+                    .unwrap()
+                    .to_string()
+            })
+            .reduce(|accum, item| [accum, item].join("\n"))
+            .unwrap(),
+    ))
+}
+
+fn create_gesture_click(row: &CenterBox) -> gtk::GestureClick {
+    let click = gtk::GestureClick::new();
+    click.connect_released(clone!(@weak row => move |me, _, _, _|{
+        if me.current_event_state().contains(gdk::ModifierType::CONTROL_MASK) {
+            return;
+        }
+        let file = get_file(&row);
+        if let Some(file) =  file.path() {
+           let _ = opener::open(file).map_err(|err| {
+                eprint!("{}", err);
+                err
+           });
+        }
+    }));
+
+    click
+}
+
+fn get_file(row: &CenterBox) -> gio::File {
+    let file_widget = if ARGS.get().unwrap().icons_only {
+        row.start_widget().unwrap()
+    } else {
+        row.center_widget().unwrap()
+    };
+    gio::File::for_path(file_widget.downcast::<Label>().unwrap().text())
+}
+
+fn setup_factory(factory: &mut SignalListItemFactory, list: &MultiSelection) {
+    factory.connect_setup(clone!(@weak list => move |_, list_item| {
+        let row = CenterBox::default();
+        let drag_source = create_drag_source(&row, &list);
+        let gesture_click = create_gesture_click(&row);
+        row.add_controller(gesture_click);
+        row.add_controller(drag_source);
+        list_item
+            .downcast_ref::<ListItem>()
+            .expect("Needs to be ListItem")
+            .set_child(Some(&row));
+    }));
+
+    factory.connect_bind(|_, list_item| {
+        let file_object = list_item
+            .downcast_ref::<ListItem>()
+            .expect("Needs to be ListItem")
+            .item()
+            .and_downcast::<FileObject>()
+            .expect("The item has to be an `FileObject`.");
+
+        let file_row = list_item
+            .downcast_ref::<ListItem>()
+            .expect("Needs to be ListItem")
+            .child()
+            .and_downcast::<CenterBox>()
+            .expect("The child has to be a `Label`.");
+
+        // show either relative or absolute path
+        let str = if file_object
+            .file()
+            .has_parent(Some(CURRENT_DIRECTORY.get().unwrap()))
+        {
+            CURRENT_DIRECTORY
+                .get()
+                .unwrap()
+                .relative_path(&file_object.file())
+                .expect("Can't make a relative path")
+                .to_str()
+                .expect("Couldn't read file name")
+                .to_string()
+        } else {
+            file_object.file().parse_name().to_string()
+        };
+
+        let label = Label::builder()
+            .label(&str)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
+            .tooltip_text(&str);
+
+        if ARGS.get().unwrap().icons_only {
+            file_row.set_start_widget(Some(&label.visible(false).build()));
+            file_row.set_center_widget(Some(&file_object.thumbnail()))
+        } else {
+            file_row.set_center_widget(Some(&label.build()));
+            file_row.set_start_widget(Some(&file_object.thumbnail()))
+        }
+    });
+}

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -1,21 +1,21 @@
-use std::{collections::HashSet, path::PathBuf};
+use std::collections::HashSet;
+use std::path::PathBuf;
 
-use crate::{
-    file_object::FileObject,
-    util::{
-        drag_source_all, generate_content_provider, setup_drop_target, setup_file_model, ListWidget,
-    },
-    ARGS, CURRENT_DIRECTORY,
-};
 use glib_macros::clone;
 use gtk::gdk::*;
+use gtk::gio::{self, ListStore};
+use gtk::prelude::*;
 use gtk::{
-    gdk,
-    gio::{self, ListStore},
-    prelude::*,
-    CenterBox, DragSource, Label, ListItem, ListView, MultiSelection, SignalListItemFactory,
+    gdk, CenterBox, DragSource, Label, ListItem, ListView, MultiSelection, SignalListItemFactory,
     Widget,
 };
+
+use crate::file_object::FileObject;
+use crate::util::{
+    generate_content_provider, generate_file_model, setup_drag_source_all, setup_drop_target,
+    ListWidget,
+};
+use crate::{ARGS, CURRENT_DIRECTORY};
 
 pub fn generate_list_view() -> ListWidget {
     let mut list_data = build_list_data();
@@ -43,15 +43,14 @@ pub fn generate_list_view() -> ListWidget {
 }
 
 fn build_list_data() -> (MultiSelection, SignalListItemFactory) {
-    // setup factory
     let factory = SignalListItemFactory::new();
-    (MultiSelection::new(Some(setup_file_model())), factory)
+    (MultiSelection::new(Some(generate_file_model())), factory)
 }
 
 fn create_drag_source(row: &CenterBox, selection: &MultiSelection) -> DragSource {
     let drag_source = DragSource::new();
     if ARGS.get().unwrap().all {
-        drag_source_all(
+        setup_drag_source_all(
             &drag_source,
             &selection.model().unwrap().downcast::<ListStore>().unwrap(),
         );

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -2,7 +2,9 @@ use std::{collections::HashSet, path::PathBuf};
 
 use crate::{
     file_object::FileObject,
-    util::{drag_source_all, generate_content_provider, setup_file_model, ListWidget},
+    util::{
+        drag_source_all, generate_content_provider, setup_drop_target, setup_file_model, ListWidget,
+    },
     ARGS, CURRENT_DIRECTORY,
 };
 use glib_macros::clone;
@@ -20,18 +22,23 @@ pub fn generate_list_view() -> ListWidget {
     setup_factory(&mut list_data.1, &list_data.0);
     let list_view = ListView::new(Some(list_data.0), Some(list_data.1));
 
+    // lol
+    let model = list_view
+        .model()
+        .unwrap()
+        .downcast::<MultiSelection>()
+        .unwrap()
+        .model()
+        .unwrap()
+        .downcast::<ListStore>()
+        .unwrap();
+    let widget = list_view.upcast::<Widget>();
+
+    setup_drop_target(&model, &widget);
+
     ListWidget {
-        // wtf??
-        list_model: list_view
-            .model()
-            .unwrap()
-            .downcast::<MultiSelection>()
-            .unwrap()
-            .model()
-            .unwrap()
-            .downcast::<ListStore>()
-            .unwrap(),
-        widget: list_view.upcast::<Widget>(),
+        list_model: model,
+        widget,
     }
 }
 

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -13,7 +13,7 @@ use url::Url;
 use crate::{file_object::FileObject, ARGS, CURRENT_DIRECTORY};
 use gtk::gdk::*;
 
-pub fn get_list_view() -> ListView {
+pub fn generate_list_view() -> ListView {
     let mut list_data = build_list_data();
     setup_factory(&mut list_data.1, &list_data.0);
     ListView::new(Some(list_data.0), Some(list_data.1))

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,9 @@ struct Cli {
 }
 
 // switch to Lazy Cell when it is stable.
+/// Constant that is initialized once on start. Contains the directory where it was started from.
 static CURRENT_DIRECTORY: OnceLock<gio::File> = OnceLock::new();
+/// Constant that is initialized once on start. clap will parse the commandline arguments into this.
 static ARGS: OnceLock<Cli> = OnceLock::new();
 
 fn main() {
@@ -138,7 +140,6 @@ fn build_ui(app: &Application) {
         .titlebar(&titlebar)
         .build();
 
-    // Kill the app when Escape is pressed
     let event_controller = EventControllerKey::new();
     event_controller.connect_key_pressed(|_, key, _, _| {
         if [gtk::gdk::Key::Escape, gtk::gdk::Key::q, gtk::gdk::Key::Q].contains(&key) {
@@ -155,6 +156,9 @@ fn build_ui(app: &Application) {
     }
 }
 
+/// Listen to input from stdin.
+/// Parses the input and checks if it is an existing file path.
+/// Valid files will be added to the model.
 fn listen_to_stdin(model: &ListStore) {
     let (sender, receiver) = MainContext::channel(Priority::default());
     gio::spawn_blocking(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,7 @@ fn setup_factory(factory: &mut SignalListItemFactory, args: &Cli) {
             .and_downcast::<CenterBox>()
             .expect("The child has to be a `Label`.");
 
+        // show either relative or absolute path
         let str = if file_object
             .file()
             .has_parent(Some(CURRENT_DIRECTORY.get().unwrap()))
@@ -249,8 +250,12 @@ fn setup_factory(factory: &mut SignalListItemFactory, args: &Cli) {
             .ellipsize(gtk::pango::EllipsizeMode::End)
             .tooltip_text(&str)
             .build();
-        file_row.set_center_widget(Some(&label));
-        file_row.set_start_widget(Some(&file_object.thumbnail()))
+        if ARGS.get().unwrap().icons_only {
+            file_row.set_center_widget(Some(&file_object.thumbnail()))
+        } else {
+            file_row.set_center_widget(Some(&label));
+            file_row.set_start_widget(Some(&file_object.thumbnail()))
+        }
     });
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn build_ui(app: &Application, args: Cli) {
     // Kill the app when Escape is pressed
     let event_controller = EventControllerKey::new();
     event_controller.connect_key_pressed(|_, key, _, _| {
-        if key.name().unwrap() == "Escape" {
+        if key == gtk::gdk::Key::Escape {
             std::process::exit(0)
         }
         glib::signal::Inhibit(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,19 @@
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 use std::sync::OnceLock;
-use std::thread;
 
 use clap::Parser;
 use compact_view::generate_compact_view;
 use file_object::FileObject;
-use gtk::gdk::ffi::gdk_content_provider_new_typed;
-use gtk::gdk::{ContentProvider, DragAction};
-use gtk::gio::ffi::g_file_get_type;
-use gtk::gio::{ApplicationFlags, File, ListStore};
-use gtk::glib::{
-    self, clone, set_program_name, Bytes, Continue, MainContext, Priority, PRIORITY_DEFAULT,
-};
+use gtk::gio::{ApplicationFlags, ListStore};
+use gtk::glib::{self, clone, set_program_name, Continue, MainContext, Priority};
 use gtk::prelude::*;
-use gtk::{
-    Application, ApplicationWindow, Button, CenterBox, DragSource, DropTarget, EventControllerKey,
-    Image, ListBox, Orientation, PolicyType, ScrolledWindow,
-};
-use url::Url;
+use gtk::{gio, Application, ApplicationWindow, EventControllerKey, PolicyType, ScrolledWindow};
+use list_view::generate_list_view;
 
+mod compact_view;
 mod file_object;
 mod list_view;
-use list_view::generate_list_view;
-mod compact_view;
 mod util;
 
 #[derive(Parser, Clone, Debug)]
@@ -90,8 +80,7 @@ struct Cli {
     paths: Vec<PathBuf>,
 }
 
-use gtk::gio;
-
+// switch to Lazy Cell when it is stable.
 static CURRENT_DIRECTORY: OnceLock<gio::File> = OnceLock::new();
 static ARGS: OnceLock<Cli> = OnceLock::new();
 
@@ -106,13 +95,13 @@ fn main() {
         .application_id("ga.strin.ripdrag")
         .flags(ApplicationFlags::NON_UNIQUE)
         .build();
-    app.connect_activate(move |app| build_ui(app, ARGS.get().unwrap()));
+    app.connect_activate(build_ui);
     app.run_with_args(&[""]); // we don't want gtk to parse the arguments. cleaner solutions are welcome
 }
 
-fn build_ui(app: &Application, args: &Cli) {
+fn build_ui(app: &Application) {
     // Parse arguments and check if files exist
-    for path in &args.paths {
+    for path in &ARGS.get().unwrap().paths {
         assert!(
             path.exists(),
             "{0} : no such file or directory",
@@ -141,11 +130,11 @@ fn build_ui(app: &Application, args: &Cli) {
     // Build the main window
     let window = ApplicationWindow::builder()
         .title("ripdrag")
-        .resizable(args.resizable)
+        .resizable(ARGS.get().unwrap().resizable)
         .application(app)
         .child(&scrolled_window)
-        .default_height(args.content_height)
-        .default_width(args.content_width)
+        .default_height(ARGS.get().unwrap().content_height)
+        .default_width(ARGS.get().unwrap().content_width)
         .titlebar(&titlebar)
         .build();
 
@@ -161,14 +150,14 @@ fn build_ui(app: &Application, args: &Cli) {
     window.add_controller(event_controller);
     window.present();
 
-    if args.from_stdin {
+    if ARGS.get().unwrap().from_stdin {
         listen_to_stdin(&list_data.list_model);
     }
 }
 
 fn listen_to_stdin(model: &ListStore) {
     let (sender, receiver) = MainContext::channel(Priority::default());
-    thread::spawn(move || {
+    gio::spawn_blocking(move || {
         let stdin = io::stdin();
         for path in stdin.lock().lines().flatten() {
             let file = gio::File::for_path(path);
@@ -189,250 +178,5 @@ fn listen_to_stdin(model: &ListStore) {
             model.append(&FileObject::new(&file));
             Continue(true)
         }),
-    );
-}
-fn build_source_ui(list_box: ListBox, args: Cli) {
-    // Populate the list with the buttons, if there are any
-    if !args.paths.is_empty() {
-        if args.all_compact {
-            list_box.append(&generate_compact(args.paths.clone(), args.and_exit));
-        } else {
-            for button in generate_buttons_from_paths(
-                args.paths.clone(),
-                args.and_exit,
-                args.icons_only,
-                args.disable_thumbnails,
-                args.icon_size,
-                args.all,
-            ) {
-                list_box.append(&button);
-            }
-        }
-    }
-
-    // Read from stdin and populate the list
-    if args.from_stdin {
-        let mut paths: Vec<PathBuf> = args.paths.clone();
-        let (sender, receiver) = MainContext::channel(PRIORITY_DEFAULT);
-        thread::spawn(move || {
-            let stdin = io::stdin();
-            let lines = stdin.lock().lines();
-
-            for line in lines {
-                let path = PathBuf::from(line.unwrap());
-                if path.exists() {
-                    println!("Adding: {}", path.display());
-                    sender.send(path).expect("Error");
-                } else if args.verbose {
-                    println!("{} : no such file or directory", path.display())
-                }
-            }
-        });
-        receiver.attach(
-                None,
-                clone!(@weak list_box => @default-return Continue(false),
-                            move |path| {
-                                if args.all_compact{
-                                    paths.push(path);
-                                    if let Some(child) = list_box.first_child() { list_box.remove(&child) }
-                                    list_box.append(&generate_compact(paths.clone(),args.and_exit));
-                                } else {
-                                    let button = generate_buttons_from_paths(vec![path],args.and_exit, args.icons_only, args.disable_thumbnails, args.icon_size, args.all);
-                                    list_box.append(&button[0]);
-                                }
-                                Continue(true)
-                            }
-                )
-            );
-    }
-}
-
-fn build_target_ui(list_box: ListBox, args: Cli) {
-    // Generate the Drop Target and button
-    let button = Button::builder().label("Drop your files here").build();
-
-    let drop_target = DropTarget::new(File::static_type(), DragAction::COPY);
-
-    let (sender, receiver) = MainContext::channel(PRIORITY_DEFAULT);
-
-    drop_target.connect_drop(move |_, value, _, _| {
-        if let Ok(file) = value.get::<File>() {
-            if let Some(path) = file.path() {
-                println!("{}", path.canonicalize().unwrap().to_string_lossy());
-                if args.keep {
-                    sender
-                        .send(path)
-                        .expect("Error while sending paths to the receiver");
-                }
-                return true;
-            }
-        }
-        false
-    });
-
-    // get the uri_list from the drop and populate the list of files (--keep)
-    let mut paths: Vec<PathBuf> = Vec::new();
-    receiver.attach(
-        None,
-        clone!(@weak list_box => @default-return Continue(false),
-                move |path| {
-                    let mut new_paths :Vec<PathBuf> = Vec::new();
-                    new_paths.push(path);
-                    if args.all_compact{
-                        // Hacky solution, check if we already created buttons
-                        if let Some(child) = list_box.last_child(){
-                            list_box.remove(&child);
-                        }
-                        paths.append(&mut new_paths);
-                        list_box.append(&generate_compact(paths.clone(),args.and_exit));
-                    } else {
-                        // This solution is fast, but it's gonna cause problems when --all is used in combinatio with --target
-                        for button in &generate_buttons_from_paths(new_paths, args.and_exit, args.icons_only, args.disable_thumbnails, args.icon_size, args.all){
-                            list_box.append(button);
-                        };
-                    }
-                    Continue(true)
-                }
-        )
-    );
-    button.add_controller(drop_target);
-    list_box.append(&button);
-}
-
-fn generate_buttons_from_paths(
-    paths: Vec<PathBuf>,
-    and_exit: bool,
-    icons_only: bool,
-    disable_thumbnails: bool,
-    icon_size: i32,
-    all: bool,
-) -> Vec<Button> {
-    let mut button_vec = Vec::new();
-    let uri_list = generate_uri_list(&paths);
-
-    //TODO: make this loop multithreaded
-    for path in paths.into_iter() {
-        // The CenterBox(button_box) contains the image and the optional label
-        // The Button contains the CenterBox and can be dragged
-        let button_box = CenterBox::builder()
-            .orientation(Orientation::Horizontal)
-            .build();
-
-        if let Some(image) = get_image_from_path(&path, icon_size, disable_thumbnails) {
-            match icons_only {
-                true => button_box.set_center_widget(Some(&image)),
-                false => button_box.set_start_widget(Some(&image)),
-            }
-        }
-
-        if !icons_only {
-            button_box.set_center_widget(Some(
-                &gtk::Label::builder()
-                    .label(path.display().to_string().as_str())
-                    .build(),
-            ));
-        }
-
-        let button = Button::builder().child(&button_box).build();
-        let drag_source = DragSource::new();
-
-        if all {
-            let list = uri_list.clone();
-            drag_source.connect_prepare(move |_, _, _| {
-                Some(ContentProvider::for_bytes("text/uri-list", &list))
-            });
-        } else {
-            let p = path.clone();
-            drag_source
-                .connect_prepare(move |_, _, _| Some(generate_content_provider_from_path(&p)));
-        }
-
-        if and_exit {
-            drag_source.connect_drag_end(|_, _, _| std::process::exit(0));
-        }
-
-        // Open the path with the default app
-        button.connect_clicked(move |_| {
-            opener::open(&path).unwrap();
-        });
-
-        button.add_controller(drag_source);
-        button_vec.push(button);
-    }
-    button_vec
-}
-
-fn generate_compact(paths: Vec<PathBuf>, and_exit: bool) -> Button {
-    // Here we want to generate a single draggable button, containg all the files
-    let button = Button::builder()
-        .label(format!("{} elements", paths.len()))
-        .build();
-    let drag_source = DragSource::new();
-
-    drag_source.connect_prepare(move |_, _, _| {
-        Some(ContentProvider::for_bytes(
-            "text/uri-list",
-            &generate_uri_list(&paths),
-        ))
-    });
-
-    if and_exit {
-        drag_source.connect_drag_end(|_, _, _| std::process::exit(0));
-    }
-    button.add_controller(drag_source);
-    button
-}
-
-fn get_image_from_path(path: &PathBuf, icon_size: i32, disable_thumbnails: bool) -> Option<Image> {
-    let mime_type = match path.metadata().unwrap().is_dir() {
-        true => "inode/directory",
-        false => match infer::get_from_path(path) {
-            Ok(option) => match option {
-                Some(infer_type) => infer_type.mime_type(),
-                None => "text/plain",
-            },
-            Err(_) => "text/plain",
-        },
-    };
-    if mime_type.contains("image") & !disable_thumbnails {
-        return Some(
-            Image::builder()
-                .file(path.as_os_str().to_str().unwrap())
-                .pixel_size(icon_size)
-                .build(),
-        );
-    }
-    gtk::gio::content_type_get_generic_icon_name(mime_type).map(|icon_name| {
-        Image::builder()
-            .icon_name(icon_name)
-            .pixel_size(icon_size)
-            .build()
-    })
-}
-
-fn generate_content_provider_from_path(path: &PathBuf) -> ContentProvider {
-    unsafe {
-        let gfile = File::for_path(path);
-        glib::translate::from_glib_full(gdk_content_provider_new_typed(g_file_get_type(), gfile))
-    }
-}
-
-fn generate_content_provider_from_file(file: &gio::File) -> ContentProvider {
-    unsafe {
-        glib::translate::from_glib_full(gdk_content_provider_new_typed(g_file_get_type(), file))
-    }
-}
-
-fn generate_uri_list(paths: &[PathBuf]) -> Bytes {
-    return gtk::glib::Bytes::from_owned(
-        paths
-            .iter()
-            .map(|path| -> String {
-                Url::from_file_path(path.canonicalize().unwrap())
-                    .unwrap()
-                    .to_string()
-            })
-            .reduce(|accum, item| [accum, item].join("\n"))
-            .unwrap(),
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ fn listen_to_stdin(model: &ListStore) {
     // weak references don't work
     receiver.attach(
         None,
-           clone!(@strong model => move |file| {
+           clone!(@weak model => @default-return Continue(false), move |file| {
             model.append(&FileObject::new(&file));
             Continue(true)
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn build_ui(app: &Application, args: Cli) {
     });
 
     window.add_controller(event_controller);
-    window.show();
+    window.set_visible(true);
 }
 
 fn build_source_ui(list_box: ListBox, args: Cli) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::borrow::BorrowMut;
-use std::collections::HashSet;
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -9,20 +7,18 @@ use clap::Parser;
 use compact_view::generate_compact_view;
 use file_object::FileObject;
 use gtk::gdk::ffi::gdk_content_provider_new_typed;
+use gtk::gdk::{ContentProvider, DragAction};
 use gtk::gio::ffi::g_file_get_type;
-use url::Url;
-
-use gtk::gdk::{self, ContentProvider, DragAction};
-use gtk::gio::{ApplicationFlags, File, ListModel, ListStore};
+use gtk::gio::{ApplicationFlags, File, ListStore};
 use gtk::glib::{
-    self, clone, closure, closure_local, set_program_name, Bytes, Continue, GString, MainContext,
-    Priority, PRIORITY_DEFAULT,
+    self, clone, set_program_name, Bytes, Continue, MainContext, Priority, PRIORITY_DEFAULT,
 };
+use gtk::prelude::*;
 use gtk::{
-    prelude::*, Application, ApplicationWindow, Button, CenterBox, DragSource, DropTarget,
-    EventControllerKey, Image, Label, ListBox, ListItem, ListView, MultiSelection, Orientation,
-    PolicyType, ScrolledWindow, SelectionModel, SignalListItemFactory,
+    Application, ApplicationWindow, Button, CenterBox, DragSource, DropTarget, EventControllerKey,
+    Image, ListBox, Orientation, PolicyType, ScrolledWindow,
 };
+use url::Url;
 
 mod file_object;
 mod list_view;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use gtk::{
 
 mod file_object;
 mod list_view;
-use list_view::get_list_view;
+use list_view::generate_list_view;
 
 #[derive(Parser, Clone, Debug)]
 #[command(about, version)]
@@ -121,7 +121,7 @@ fn build_ui(app: &Application, args: &Cli) {
         );
     }
     // Create a scrollable list
-    let list_view = get_list_view();
+    let list_view = generate_list_view();
     let scrolled_window = ScrolledWindow::builder()
         .hscrollbar_policy(PolicyType::Never) //  Disable horizontal scrolling
         .min_content_width(args.content_width)

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,3 @@
+.drag:hover {
+    opacity: 0.5;
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,7 @@ use url::Url;
 use crate::file_object::FileObject;
 use crate::ARGS;
 
+/// Helper record type.
 pub struct ListWidget {
     pub list_model: ListStore,
     pub widget: Widget,
@@ -28,6 +29,7 @@ pub fn generate_file_model() -> ListStore {
     file_model
 }
 
+/// Returns data for dragging files.
 pub fn generate_content_provider<'a>(
     paths: impl IntoIterator<Item = &'a PathBuf>,
 ) -> Option<ContentProvider> {
@@ -44,10 +46,11 @@ pub fn generate_content_provider<'a>(
     if bytes.is_empty() {
         None
     } else {
-        Some(ContentProvider::for_bytes("text/uri-list", &bytes))
+        Some(ContentProvider::for_bytes("text/uri-list", bytes))
     }
 }
 
+/// For the -a or -A flag.
 pub fn setup_drag_source_all(drag_source: &DragSource, list_model: &ListStore) {
     drag_source.connect_prepare(
         clone!(@weak list_model => @default-return None, move |me, _, _| {
@@ -59,6 +62,8 @@ pub fn setup_drag_source_all(drag_source: &DragSource, list_model: &ListStore) {
     );
 }
 
+/// TODO: This will not work for directories <https://gitlab.gnome.org/GNOME/gtk/-/issues/5348>.
+/// Will add dropped files to the model.
 pub fn setup_drop_target(model: &ListStore, widget: &Widget) {
     let drop_target = DropTarget::builder()
         .name("file-drop-target")

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,58 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use gtk::gio::ListModel;
+use gtk::{
+    gdk::ContentProvider, gio::ListStore, glib::clone, prelude::*, CenterBox, DragSource, Label,
+    MultiSelection, Widget,
+};
+use gtk::{gio, glib};
+use url::Url;
+
+use crate::{file_object::FileObject, ARGS};
+
+pub struct ListWidget {
+    pub list_model: ListStore,
+    pub widget: Widget,
+}
+
+pub fn setup_file_model() -> ListStore {
+    let file_model = ListStore::new(FileObject::static_type());
+    let files: Vec<FileObject> = ARGS
+        .get()
+        .unwrap()
+        .paths
+        .iter()
+        .map(|path| FileObject::new(&gtk::gio::File::for_path(path)))
+        .collect();
+    file_model.extend_from_slice(&files);
+    file_model
+}
+
+pub fn generate_content_provider<'a>(
+    paths: impl IntoIterator<Item = &'a PathBuf>,
+) -> Option<ContentProvider> {
+    let bytes = &gtk::glib::Bytes::from_owned(
+        paths
+            .into_iter()
+            .map(|path| -> String {
+                Url::from_file_path(path.canonicalize().unwrap())
+                    .unwrap()
+                    .to_string()
+            })
+            .fold("".to_string(), |accum, item| [accum, item].join("\n")),
+    );
+    if bytes.is_empty() {
+        None
+    } else {
+        Some(ContentProvider::for_bytes("text/uri-list", &bytes))
+    }
+}
+
+pub fn drag_source_all(drag_source: &DragSource, list_model: &ListStore) {
+    drag_source.connect_prepare(clone!(@weak list_model => @default-return None, move |me, _, _| {
+            me.set_state(gtk::EventSequenceState::Claimed);
+            let files: Vec<PathBuf> = list_model.into_iter().flatten().map(|file_object| {file_object.downcast::<FileObject>().unwrap().file().path().unwrap()}).collect();
+            generate_content_provider(&files)
+        }));
+}


### PR DESCRIPTION
Quite a lot of changes in this pull request. I doubt that I can split it up.

# Internal changes

- Move to ListView because it's more efficient.
- ListView and CompactView are in their own files.
- Updated GTK version for newer API and macros.
- Commandline arguments are globally accessible with a OnceCell (move to LazyCell when it hits stable).

# Enhancements

- Thumbnails are generated in a multithreaded way. No more lags.
- Memory usage decreased by only storing needed thumbnail size.
- Drag and Drop Area is the entire window.
- Dropping multiple files is now possible
- Window width and height is now correctly applied
- --target can accept multiple files.

# New features

- Multiselection. Hold CTRL to select files to drag. Will move to single drag when dragging something that is not selected. (Opening is still single selection)
- Removed window decorations. 
- Q and q will also quit the application.
- No more buttons because they do not wrap their text.