### PR TITLE
Rework -a Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Options:
   -W, --content-width <WIDTH>    Min width of the main window [default: 360]
   -H, --content-height <HEIGHT>  Default height of the main window [default: 360]
   -I, --from-stdin               Accept paths from stdin
-  -a, --all                      Drag all the items together
+  -a, --all                      Show a drag all button
   -A, --all-compact              Show only the number of items and drag them together
   -n, --no-click                 Don't open files on click
   -b, --basename                 Always show basename of each file

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,8 @@
 use gtk::gdk::{ContentProvider, DragAction, FileList};
 use gtk::gio::{self, File, ListStore};
 use gtk::glib::{clone, Bytes};
-use gtk::prelude::*;
 use gtk::{gdk, glib, DragSource, DropTarget, EventSequenceState, Widget};
+use gtk::prelude::*;
 
 use crate::file_object::FileObject;
 use crate::ARGS;
@@ -31,13 +31,13 @@ pub fn generate_content_provider<'a>(
     paths: impl IntoIterator<Item = &'a String>,
 ) -> Option<ContentProvider> {
     let mut uri_list = paths
-            .into_iter()
-            .cloned()
-            .collect::<Vec<String>>()
-            .join("\r\n");
-    
+        .into_iter()
+        .cloned()
+        .collect::<Vec<String>>()
+        .join("\r\n");
+
     if uri_list.is_empty() {
-        return None
+        return None;
     } else {
         uri_list += "\r\n";
         let bytes = Bytes::from(uri_list.as_bytes());


### PR DESCRIPTION
Reworks the `-a` option to show a drag all files button instead of always dragging all files together. (#33)