### PR TITLE
Fix drag-and-drop for sandboxed Flatpak apps (e.g., Telegram)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/.vscode"]
 
 [dependencies]
 clap = { version = "4.5.51", features = ["derive"] }
-gtk = { version = "0.10.1", package = "gtk4", features = ["v4_6"] }
+gtk = { version = "0.10.1", package = "gtk4", features = ["v4_8"] }
 glib-macros = "0.21.2"
 opener = "0.8.3"
 async-channel = "2.5.0"

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use gtk::gdk::{ContentProvider, DragAction, FileList};
 use gtk::gio::{self, File, ListStore};
-use gtk::glib::{clone, Bytes};
+use gtk::glib::clone;
 use gtk::prelude::*;
 use gtk::{gdk, glib, DragSource, DropTarget, EventSequenceState, Widget};
 
@@ -33,19 +33,14 @@ pub fn generate_file_model() -> ListStore {
 pub fn generate_content_provider<'a>(
     paths: impl IntoIterator<Item = &'a String>,
 ) -> Option<ContentProvider> {
-    let mut uri_list = paths
-        .into_iter()
-        .cloned()
-        .collect::<Vec<String>>()
-        .join("\r\n");
+    let files: Vec<File> = paths.into_iter().map(|p| File::for_uri(p)).collect();
 
-    if uri_list.is_empty() {
+    if files.is_empty() {
         return None;
-    } else {
-        uri_list += "\r\n";
-        let bytes = Bytes::from(uri_list.as_bytes());
-        Some(ContentProvider::for_bytes("text/uri-list", &bytes))
     }
+    let files_list = FileList::from_array(&files);
+
+    Some(ContentProvider::for_value(&files_list.to_value()))
 }
 /// For the -a or -A flag.
 pub fn setup_drag_source_all(drag_source: &DragSource, list_model: &ListStore) {


### PR DESCRIPTION
Fixes #53 

### Description
This PR fixes an issue where dragging files into strictly sandboxed Flatpak applications (like Telegram) resulted in "File is empty" or "Permission denied" errors.

### Changes Made:
* **Switched to native `FileList`:** Replaced `ContentProvider::for_bytes` with `ContentProvider::for_value(&FileList)`. This ensures that GTK correctly registers the dragged files with `xdg-desktop-portal`, granting the target Flatpak app the necessary read permissions.
* **Fixed URI parsing:** `File::for_uri` in `generate_content_provider`. The function was receiving already-formatted URIs (like `file:///...`) from `setup_drag_source_all`.
* **Bumped GTK feature:** Bumped the `gtk4` feature flag in `Cargo.toml` from `v4_6` to `v4_8` to utilize the `FileList::from_array` method. 

Tested locally on Arch Linux with Flatpak Telegram Desktop. Works flawlessly. Let me know if the `v4_8` version bump is acceptable for the project's compatibility goals!